### PR TITLE
Added visual buff icon for when "Start with Aghs" is enabled

### DIFF
--- a/src/scripts/vscripts/pregame.lua
+++ b/src/scripts/vscripts/pregame.lua
@@ -4371,7 +4371,7 @@ function Pregame:fixSpawningIssues()
 
                 -- Handle free scepter stuff
                 if OptionManager:GetOption('freeScepter') then
-                    spawnedUnit:AddNewModifier(spawnedUnit, nil, 'modifier_item_ultimate_scepter', {
+                    spawnedUnit:AddNewModifier(spawnedUnit, nil, 'modifier_item_ultimate_scepter_consumed', {
                         bonus_all_stats = 0,
                         bonus_health = 0,
                         bonus_mana = 0


### PR DESCRIPTION
Changed the granted modifier from regular aghs item, to the aghs upgrade that alch gives. The only difference is that the alch one comes with the visual buff. It still does not give any extra stats. I think its a nice touch for players to know from the start they have aghs (incase they were not paying attention to settings, or are newbs). The only thing that I would change if I knew how, would be to change the tooltip description when you hover over the buff. It says it grants stats, and it does'nt.
![image](https://cloud.githubusercontent.com/assets/16277198/14998245/4f1eee34-11c6-11e6-9215-a52cb7f4413d.png)
